### PR TITLE
Servidor daemon

### DIFF
--- a/cmd/simpd/api/README.md
+++ b/cmd/simpd/api/README.md
@@ -1,0 +1,9 @@
+ - post /sts/job/id_job - lançar o job
+ - delete /sts/job/id_job - matar o job
+ - get  /sts/job/id_job - status do processo
+
+ - get  /sts/jobs - pega todos os processos em execução
+ - get /sts/queue - pega todos os processos na fila
+
+ - delete /sts/queue - deleta todos os jobs na fila 
+ - delete /sts/jobs - deleta todos os jobs em execução

--- a/cmd/simpd/api/api.go
+++ b/cmd/simpd/api/api.go
@@ -1,0 +1,40 @@
+// Package api é o pacote que define o lado do daemon da API do SIMP. Cria as rotas e inicializa o servidor
+// além de fazer os handlers para alterações nos processos. Esses handlers dependem de interfaces
+// a serem implementadas, de criação, monitoramento e deleção de jobs.
+//
+// O valor necessário no corpo dos requests são as estruturas definidas em pkg/meta.
+package api
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/lucasclopesr/Simple-Task-Scheduler/pkg/transport"
+)
+
+// Server é um servidor que trata as rotas e requests da API rest entre
+// CLI e daemon do SIMP
+type Server struct {
+	router   *mux.Router
+	listener net.Listener
+}
+
+// NewServer inicializa um servidor com a configuração de unix socket
+func NewServer() (Server, error) {
+	// ouvindo em unix sockets
+	listener, err := net.Listen("unix", transport.UnixSocketAddress)
+	if err != nil {
+		return Server{}, err
+	}
+
+	return Server{
+		listener: listener,
+		router:   mux.NewRouter(),
+	}, nil
+}
+
+// Run roda o servidor
+func (s *Server) Run() error {
+	return http.Serve(s.listener, s.router)
+}

--- a/cmd/simpd/api/handlers/errors.go
+++ b/cmd/simpd/api/handlers/errors.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/lucasclopesr/Simple-Task-Scheduler/pkg/simperr"
+)
+
+func handleError(err error, w http.ResponseWriter, r *http.Request) {
+	encoder := json.NewEncoder(w)
+	var status int
+	serr, ok := err.(*simperr.SimpError)
+	if !ok {
+		status = http.StatusInternalServerError
+	} else {
+		switch serr.Code {
+		case simperr.ErrorAlreadyExists:
+			status = http.StatusConflict
+		case simperr.ErrorJobLimit, simperr.ErrorMemoryLimit:
+			status = http.StatusTooManyRequests
+		case simperr.ErrorNotFound:
+			status = http.StatusNotFound
+		}
+	}
+
+	w.WriteHeader(status)
+	encoder.Encode(serr)
+}

--- a/cmd/simpd/api/handlers/interface.go
+++ b/cmd/simpd/api/handlers/interface.go
@@ -1,0 +1,23 @@
+package handlers
+
+import "github.com/lucasclopesr/Simple-Task-Scheduler/pkg/meta"
+
+// SetJobHandler assina a variável jh que faz modificações nas estruturas de job
+// existentes
+func SetJobHandler(jobHandler JobHandler) {
+	jh = jobHandler
+}
+
+// JobHandler representa uma estrutura que consegue modificar e
+// requerir informações sobre os jobs atualmente no sistema
+type JobHandler interface {
+	CreateJob(string, meta.JobRequest) error
+	DeleteJob(string) error
+	GetJob(string) (meta.Job, error)
+	GetExecutingJobs() ([]meta.Job, error)
+	DeleteExecutingJobs() error
+	GetQueuedJobs() ([]meta.Job, error)
+	DeleteQueuedJobs() error
+}
+
+var jh JobHandler

--- a/cmd/simpd/api/handlers/job.go
+++ b/cmd/simpd/api/handlers/job.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/lucasclopesr/Simple-Task-Scheduler/pkg/meta"
+)
+
+// HandleGetJob trata requisitos de m'etodo GET no caminho /job
+func handleGetJob(w http.ResponseWriter, r *http.Request) {
+	var job meta.Job
+	encoder := json.NewEncoder(w)
+
+	vars := mux.Vars(r)
+	jobID := vars["id_job"]
+
+	job, err := jh.GetJob(jobID)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+	err = encoder.Encode(job)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandlePostJob trata requisitos de m'etodo POST no caminho /job
+func handlePostJob(w http.ResponseWriter, r *http.Request) {
+	var job meta.JobRequest
+
+	vars := mux.Vars(r)
+	jobID := vars["id_job"]
+
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&job)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	err = jh.CreateJob(jobID, job)
+	if err != nil {
+		handleError(err, w, r)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleDeleteJob trata requisitos de m'etodo DELETE no caminho /job
+func handleDeleteJob(w http.ResponseWriter, r *http.Request) {
+
+	vars := mux.Vars(r)
+	jobID := vars["id_job"]
+
+	err := jh.DeleteJob(jobID)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleJob trata a rota /job/{id_job}
+func HandleJob(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		handleGetJob(w, r)
+	case http.MethodPost:
+		handlePostJob(w, r)
+	case http.MethodDelete:
+		handleDeleteJob(w, r)
+	}
+}

--- a/cmd/simpd/api/handlers/jobs.go
+++ b/cmd/simpd/api/handlers/jobs.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/lucasclopesr/Simple-Task-Scheduler/pkg/meta"
+)
+
+// HandleGetJobs trata requisitos de m'etodo GET no caminho /jobs
+func handleGetJobs(w http.ResponseWriter, r *http.Request) {
+	var jobs []meta.Job
+	encoder := json.NewEncoder(w)
+
+	jobs, err := jh.GetExecutingJobs()
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+	err = encoder.Encode(jobs)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleDeleteQueue trata requisitos de m'etodo GET no caminho /queue
+func handleDeleteJobs(w http.ResponseWriter, r *http.Request) {
+
+	err := jh.DeleteExecutingJobs()
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleJobs trata a rota /jobs
+func HandleJobs(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		handleGetJobs(w, r)
+	case http.MethodDelete:
+		handleDeleteJobs(w, r)
+	}
+}

--- a/cmd/simpd/api/handlers/json.go
+++ b/cmd/simpd/api/handlers/json.go
@@ -1,0 +1,11 @@
+package handlers
+
+import "net/http"
+
+// JSON coloca o header de Content-Type para application/json no handler
+func JSON(next func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		next(w, r)
+	}
+}

--- a/cmd/simpd/api/handlers/queue.go
+++ b/cmd/simpd/api/handlers/queue.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/lucasclopesr/Simple-Task-Scheduler/pkg/meta"
+)
+
+// HandleGetQueue trata requisitos de m'etodo GET no caminho /queue
+func handleGetQueue(w http.ResponseWriter, r *http.Request) {
+	var jobs []meta.Job
+	encoder := json.NewEncoder(w)
+
+	jobs, err := jh.GetQueuedJobs()
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+	err = encoder.Encode(jobs)
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleDeleteQueue trata requisitos de m'etodo GET no caminho /queue
+func handleDeleteQueue(w http.ResponseWriter, r *http.Request) {
+
+	err := jh.DeleteQueuedJobs()
+	if err != nil {
+		handleError(err, w, r)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleQueue trata a rota /job/{id_job}
+func HandleQueue(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		handleGetQueue(w, r)
+	case http.MethodDelete:
+		handleDeleteQueue(w, r)
+	}
+}

--- a/cmd/simpd/api/init.go
+++ b/cmd/simpd/api/init.go
@@ -13,7 +13,7 @@ func (s *Server) Init(jobHandler handlers.JobHandler) {
 		handlers.JSON(handlers.HandleJobs),
 	).Methods("GET", "DELETE")
 
-	s.router.HandleFunc("queue",
+	s.router.HandleFunc("/queue",
 		handlers.JSON(handlers.HandleQueue),
 	).Methods("GET", "DELETE")
 

--- a/cmd/simpd/api/init.go
+++ b/cmd/simpd/api/init.go
@@ -1,0 +1,22 @@
+package api
+
+import "github.com/lucasclopesr/Simple-Task-Scheduler/cmd/simpd/api/handlers"
+
+// Init inicializa o server com as rotas necessárias e o handler que faz alterações nos
+// processos existentes
+func (s *Server) Init(jobHandler handlers.JobHandler) {
+	s.router.HandleFunc("/job/{id_job}",
+		handlers.JSON(handlers.HandleJob),
+	).Methods("GET", "POST", "DELETE")
+
+	s.router.HandleFunc("/jobs",
+		handlers.JSON(handlers.HandleJobs),
+	).Methods("GET", "DELETE")
+
+	s.router.HandleFunc("queue",
+		handlers.JSON(handlers.HandleQueue),
+	).Methods("GET", "DELETE")
+
+	// especifica o objeto que fará alteração nos jobs e processos
+	handlers.SetJobHandler(jobHandler)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/lucasclopesr/Simple-Task-Scheduler
 
 go 1.13
+
+require github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/pkg/meta/job.go
+++ b/pkg/meta/job.go
@@ -1,3 +1,4 @@
 package meta
 
+// Job representa um Job do simp
 type Job struct{}

--- a/pkg/meta/job.go
+++ b/pkg/meta/job.go
@@ -1,0 +1,3 @@
+package meta
+
+type Job struct{}

--- a/pkg/meta/job_request.go
+++ b/pkg/meta/job_request.go
@@ -1,0 +1,6 @@
+package meta
+
+type JobRequest struct {
+	User string `yaml:"user"  json:"user"`
+	Job  Job    `yaml:"job"  json:"job"`
+}

--- a/pkg/meta/job_request.go
+++ b/pkg/meta/job_request.go
@@ -1,5 +1,6 @@
 package meta
 
+// JobRequest representa um request de criação de job
 type JobRequest struct {
 	User string `yaml:"user"  json:"user"`
 	Job  Job    `yaml:"job"  json:"job"`

--- a/pkg/simperr/error.go
+++ b/pkg/simperr/error.go
@@ -1,5 +1,6 @@
 package simperr
 
+// SimpError é um erro do SIMP
 type SimpError struct {
 	Code    int    `yaml:"code"  json:"code"`
 	Message string `yaml:"message"  json:"message"`
@@ -9,6 +10,7 @@ func (s *SimpError) Error() string {
 	return s.Message
 }
 
+// Códigos de erro comuns
 const (
 	ErrorNotFound = iota
 	ErrorAlreadyExists

--- a/pkg/simperr/error.go
+++ b/pkg/simperr/error.go
@@ -1,0 +1,17 @@
+package simperr
+
+type SimpError struct {
+	Code    int    `yaml:"code"  json:"code"`
+	Message string `yaml:"message"  json:"message"`
+}
+
+func (s *SimpError) Error() string {
+	return s.Message
+}
+
+const (
+	ErrorNotFound = iota
+	ErrorAlreadyExists
+	ErrorMemoryLimit
+	ErrorJobLimit
+)

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+// UnixSocketAddress é o endereço de comunicação em unix socket
 const UnixSocketAddress = "/var/run/insprd.sock"
 
 // NewUnixSocketClient returna um client que conecta via unix socket

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -1,0 +1,19 @@
+package transport
+
+import (
+	"net"
+	"net/http"
+)
+
+const UnixSocketAddress = "/var/run/insprd.sock"
+
+// NewUnixSocketClient returna um client que conecta via unix socket
+func NewUnixSocketClient() http.Client {
+	return http.Client{
+		Transport: &http.Transport{
+			Dial: func(string, string) (net.Conn, error) {
+				return net.Dial("unix", UnixSocketAddress)
+			},
+		},
+	}
+}


### PR DESCRIPTION
# História
**Como usuário, quero conseguir me comunicar com o criador de tarefas através da CLI, para que possa criar e deletar jobs.**

## Mudanças
Implementa o servidor do daemon, com as rotas definidas a seguir:

```
post /sts/job/id_job - lançar o job
delete /sts/job/id_job - matar o job
get  /sts/job/id_job - status do processo

get  /sts/jobs - pega todos os processos em execução
get /sts/queue - pega todos os processos na fila

delete /sts/queue - deleta todos os jobs na fila 
delete /sts/jobs - deleta todos os jobs em execução
```

O servidor inicializa um unix socket na rota "/var/run/simp.sock" e faz comunicações utilizando o protocolo HTTP com uma API RESTful.

A rota de POST tem como parâmetro um objeto do tipo JobRequest, que está implementado como um stub na pasta `meta`.